### PR TITLE
Add IsSharingGPU function 

### DIFF
--- a/autonomous-scheduler/vGPUScheduler/pkg/alnair-cost-saving/alnaircostsaving.go
+++ b/autonomous-scheduler/vGPUScheduler/pkg/alnair-cost-saving/alnaircostsaving.go
@@ -108,10 +108,18 @@ func (g *alnaircostsaving) Filter(ctx context.Context, state *framework.CycleSta
 		return framework.NewStatus(framework.Error, fmt.Sprintf("cannot patch timestamp to pod %s, err: %v", pod.Name, err))
 	}
 
-	nodeinfos := utils.NewNodeInfos(node.Node())
-	if allocatable := nodeinfos.Assume(pod); allocatable {
-		return framework.NewStatus(framework.Success, "")
-	}
+    if sharing := utils.IsGPUsharingPod(pod); sharing {
+        klog.V(5).Infof("filter pod: %v with requests on GPU", pod.Name)
+	    nodeinfos := utils.NewNodeInfos(node.Node())
+	    if allocatable := nodeinfos.Assume(pod); allocatable {
+		    return framework.NewStatus(framework.Success, "")
+	    }
+
+    } else {
+        klog.V(5).Infof("filter pod: %v without requesting GPU", pod.Name)
+	    return framework.NewStatus(framework.Success, "")
+    }
+
 
 	return framework.NewStatus(framework.Unschedulable, "Node:"+node.Node().Name)
 }


### PR DESCRIPTION
If a pod is not using any GPU resource, then it should not go through the scheduler for assigning GPU-related jobs