### PR TITLE
removed a space; changed memory size type long long

### DIFF
--- a/alnair-device-plugin/intercept-lib/src/cuda_metrics.cc
+++ b/alnair-device-plugin/intercept-lib/src/cuda_metrics.cc
@@ -46,7 +46,7 @@ void log_api_call(const int pid, const int memUsed, const int kernelCnt, const i
     auto duration = now.time_since_epoch();                                                     
     std::ofstream fmet (metrices_file);                                                                         
     //print timestamp at nano seconds when a cuda API is called                                                                     
-    fmet << "pid:" << pid << "\nkernel-cnt:" << kernelCnt << "\nmem-used:" << memUsed << "\ntoken-cnt: "  << tokens << std::endl;                                     
+    fmet << "pid:" << pid << "\nkernel-cnt:" << kernelCnt << "\nmem-used:" << memUsed << "\ntoken-cnt:"  << tokens << std::endl;                                     
     fmet.close();                                                                               
 }  
 

--- a/alnair-device-plugin/intercept-lib/src/cuda_metrics.h
+++ b/alnair-device-plugin/intercept-lib/src/cuda_metrics.h
@@ -20,7 +20,7 @@ limitations under the License.
 typedef struct cuda_metrics {
     pthread_mutex_t mutex;
     unsigned int kernelCnt;
-    unsigned int memUsed;
+    unsigned long long memUsed;
     unsigned int pid;
     unsigned int token;
     struct timespec period;


### PR DESCRIPTION
fixed two issues:
1.  remove a space in 'token' field
2. changed memory size type to long long to solve overflowing issue.